### PR TITLE
Fixed views not being removed from the item container.

### DIFF
--- a/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
+++ b/bottom-bar/src/main/java/com/roughike/bottombar/BottomBar.java
@@ -1671,7 +1671,7 @@ public class BottomBar extends RelativeLayout implements View.OnClickListener, V
 
             if (childCount > 0) {
                 for (int i = 0; i < childCount; i++) {
-                    mItemContainer.removeView(mItemContainer.getChildAt(i));
+                    mItemContainer.removeView(mItemContainer.getChildAt(0));
                 }
             }
         }


### PR DESCRIPTION
Removing views works like a cascade delete.
If you have 3 views to remove, you remove position 0, then position 2,
when you get to position 3, you only have one child at 0. This child
will not be deleted.
You can remove by index in decreasing order or just remove at index 0.
